### PR TITLE
Add a helper class to radio buttons

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,8 @@ public function fields(Request $request)
     return [
         RadioButton::make('Can view skip adverts')
             ->options([
-                0 => 'No',
-                1 => 'Yes',
+                0 => ['No'],
+                1 => ['Yes','This means that users will not have to watch adverts'],
             ])
             ->default(0) // optional
             ->stack() // optional

--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -9,7 +9,8 @@
         </div>
         <div class="w-3/4 py-4">
             <slot name="value">
-                <p class="text-90" :title="this.field.value" :aria-label="this.field.value">{{ value }}</p>
+                <p class="text-90" :title="this.field.value" :aria-label="this.field.value">{{ value[0] }}</p>
+                <span class="radio-helper" v-if="value[1]">{{ value[1] }}</span>
             </slot>
         </div>
     </div>

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -8,7 +8,9 @@
                     <label :for="`${field.attribute}_${val}`">
                         <input v-model="value" :value="val" :id="`${field.attribute}_${val}`" :name="field.attribute"
                                type="radio">
-                        <span class="radio-label">{{ option }}</span>
+                        <span class="radio-label">{{ option[0] }}</span>
+                        <br>
+                        <span class="radio-helper">{{ option[1] }}</span>
                     </label>
                 </div>
             </div>

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -9,7 +9,6 @@
                         <input v-model="value" :value="val" :id="`${field.attribute}_${val}`" :name="field.attribute"
                                type="radio">
                         <span class="radio-label">{{ option[0] }}</span>
-                        <br>
                         <span class="radio-helper">{{ option[1] }}</span>
                     </label>
                 </div>

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -9,7 +9,7 @@
                         <input v-model="value" :value="val" :id="`${field.attribute}_${val}`" :name="field.attribute"
                                type="radio">
                         <span class="radio-label">{{ option[0] }}</span>
-                        <span class="radio-helper" v-if="field.stack">{{ option[1] }}</span>
+                        <span class="radio-helper form-field" v-if="field.stack && option[1]">{{ option[1] }}</span>
                     </label>
                 </div>
             </div>

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -9,7 +9,7 @@
                         <input v-model="value" :value="val" :id="`${field.attribute}_${val}`" :name="field.attribute"
                                type="radio">
                         <span class="radio-label">{{ option[0] }}</span>
-                        <span class="radio-helper">{{ option[1] }}</span>
+                        <span class="radio-helper" v-if="field.stack">{{ option[1] }}</span>
                     </label>
                 </div>
             </div>

--- a/resources/js/components/IndexField.vue
+++ b/resources/js/components/IndexField.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :title="this.field.value" :aria-label="this.field.value">{{ value }}</div>
+    <div :title="this.field.value" :aria-label="this.field.value">{{ value[0] }}</div>
 </template>
 
 <script>

--- a/resources/sass/field.scss
+++ b/resources/sass/field.scss
@@ -7,6 +7,6 @@
   margin-left: 23px;
 }
 
-.radio-helper, .form-field {
+.form-field {
   margin-left: 23px;
 }

--- a/resources/sass/field.scss
+++ b/resources/sass/field.scss
@@ -6,3 +6,7 @@
   color: #8c8c8c;
   margin-left: 23px;
 }
+
+.radio-helper, .form-field {
+  margin-left: 23px;
+}

--- a/resources/sass/field.scss
+++ b/resources/sass/field.scss
@@ -1,1 +1,8 @@
 // Nova Tool CSS
+.radio-helper {
+  display: block;
+  font-style: normal;
+  font-size: 13px;
+  color: #8c8c8c;
+  margin-left: 23px;
+}


### PR DESCRIPTION
This adds a span under the radio button that allows for a description to be added about what the radio button may do.

It is as easy as adding this in `public function fields()`
```
RadioButton::make('Administrator type', 'is_super_admin')
                ->options([
                    0 => ['Regular administrator'],
                    1 => ['Super administrator','Super administrators have all administrator permissions and can manage other admins.'],
                ])
                ->stack()
```