### PR TITLE
Remove empty CSS

### DIFF
--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -17,7 +17,6 @@ class FieldServiceProvider extends ServiceProvider
     {
         Nova::serving(function (ServingNova $event) {
             Nova::script('radio-field', __DIR__.'/../dist/js/field.js');
-            Nova::style('radio-field', __DIR__.'/../dist/css/field.css');
         });
     }
 


### PR DESCRIPTION
There is no benefit in loading the stylesheet when it's only referring to an empty file.

![image](https://user-images.githubusercontent.com/12232155/126336183-512e336c-7d04-4d68-8a36-e21bb46eb978.png)

laravel/nova-issues#3474